### PR TITLE
增加plop模板对应的vscode的snippets生成配置

### DIFF
--- a/.vscode/vue.code-snippets
+++ b/.vscode/vue.code-snippets
@@ -1,0 +1,51 @@
+{
+	"console.log": {
+		"scope": "javascript,typescript,vue",
+		"prefix": "con",
+		"body": [
+			"console.log($1)"
+		],
+		"description": "Log output to console"
+	},
+	"style postcss scoped": {
+		"scope": "vue",
+		"prefix": "style",
+		"body": [
+            "<style lang='less' scoped>",
+            "    $1",
+            "</style>"
+		],
+		"description": ""
+	},
+	"Const statement": {
+		"prefix": ["const statement"],
+		"body": [
+			"const { $0 } = ${1:function}()"
+		],
+		"description": "Const statement"
+	},
+	"vue新建页面": {
+		"scope": "vue",
+		"prefix": "page",
+		"body": [
+            "<template>",
+            "    <div>",
+            "       $2",
+            "    </div>",
+            "</template>",
+
+            "",
+
+            "<script setup lang='ts'>",
+            "    $1",
+            "</script>",
+
+            "",
+            
+            "<style lang='less' scoped>",
+            "    $3",
+            "</style>"
+		],
+		"description": "vue page"
+	}
+}

--- a/.vscode/vue.code-snippets
+++ b/.vscode/vue.code-snippets
@@ -1,50 +1,46 @@
 {
-	"console.log": {
-		"scope": "javascript,typescript,vue",
-		"prefix": "con",
+	"store新建页面": {
+		"scope": "typescript",
+		"prefix": "store",
 		"body": [
-			"console.log($1)"
+			"import { defineStore } from 'pinia'",
+			"import { piniaStore } from '@/store'",
+			"",
+			"export const use$1Store = defineStore(",
+			"    '${1/(.*)/${1:/camelcase}/}',",
+			"    {",
+			"        state: () => ({}),",
+			"        getters: {},",
+			"        actions: {}",
+			"    }",
+			")",
+			"",
+			"export function use$1OutsideStore() {",
+			"    return use$1Store(piniaStore)",
+			"}"
 		],
-		"description": "Log output to console"
-	},
-	"style postcss scoped": {
-		"scope": "vue",
-		"prefix": "style",
-		"body": [
-            "<style lang='less' scoped>",
-            "    $1",
-            "</style>"
-		],
-		"description": ""
-	},
-	"Const statement": {
-		"prefix": ["const statement"],
-		"body": [
-			"const { $0 } = ${1:function}()"
-		],
-		"description": "Const statement"
+		"description": "store page"
 	},
 	"vue新建页面": {
 		"scope": "vue",
 		"prefix": "page",
 		"body": [
-            "<template>",
-            "    <div>",
-            "       $2",
-            "    </div>",
-            "</template>",
-
-            "",
-
-            "<script setup lang='ts'>",
-            "    $1",
-            "</script>",
-
-            "",
-            
-            "<style lang='less' scoped>",
-            "    $3",
-            "</style>"
+			"<template>",
+			"    <div>",
+			"       $3",
+			"    </div>",
+			"</template>",
+			"",
+			"<script setup name='$1'>",
+			"// const { proxy } = getCurrentInstance()",
+			"// const router = useRouter()",
+			"// const route = useRoute()",
+			"    $2",
+			"</script>",
+			"",
+			"<style lang='less' scoped>",
+			"    $4",
+			"</style>"
 		],
 		"description": "vue page"
 	}


### PR DESCRIPTION
对应vscode的使用用户，通过默认支持的snippets，可以更加友好快速的创建模板，现增加的page和store是和plop的模板对应，通过在vscode编码中，执行一下可以快速创建模板：
- 输入`page`，然后tab，可快速生成vue页面模板
- 输入`store`，然后tab，可快速生成store相关代码模板